### PR TITLE
fix empty key_name on aws_spot_fleet_request

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -350,7 +350,7 @@ func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{
 		opts.UserData = aws.String(base64Encode([]byte(v.(string))))
 	}
 
-	if v, ok := d["key_name"]; ok {
+	if v, ok := d["key_name"]; ok && v != "" {
 		opts.KeyName = aws.String(v.(string))
 	}
 

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -1364,9 +1364,10 @@ resource "aws_spot_fleet_request" "foo" {
     target_capacity = 1
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
     launch_specification {
         instance_type = "m1.small"
-        ami = "ami-d06a90b0"
+        ami = "ami-516b9131"
 
 	ebs_block_device {
             device_name = "/dev/xvda"


### PR DESCRIPTION
> https://github.com/terraform-providers/terraform-provider-aws/issues/492

*internal review before I create an upstream PR*

This fixes the issue where creating a spot fleet fails, because the `key_name` is empty.

@rebuy-de/it-platform Please review.