### PR TITLE
add wait_for_fulfillment to spot_fleet_request

### DIFF
--- a/aws/resource_aws_spot_fleet_request.go
+++ b/aws/resource_aws_spot_fleet_request.go
@@ -638,8 +638,8 @@ func resourceAwsSpotFleetRequestCreate(d *schema.ResourceData, meta interface{})
 		spotStateConf := &resource.StateChangeConf{
 			Pending:    []string{"pending_fulfillment"},
 			Target:     []string{"fulfilled"},
-			Refresh:    resourceAwsSpotFleetRequestFulfillmentRefreshFunc(d, meta),
-			Timeout:    10 * time.Minute,
+			Refresh:    resourceAwsSpotFleetRequestFulfillmentRefreshFunc(d.Id(), meta.(*AWSClient).ec2conn),
+			Timeout:    d.Timeout(schema.TimeoutCreate),
 			Delay:      10 * time.Second,
 			MinTimeout: 3 * time.Second,
 		}
@@ -681,11 +681,10 @@ func resourceAwsSpotFleetRequestStateRefreshFunc(d *schema.ResourceData, meta in
 	}
 }
 
-func resourceAwsSpotFleetRequestFulfillmentRefreshFunc(d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+func resourceAwsSpotFleetRequestFulfillmentRefreshFunc(id string, conn *ec2.EC2) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		conn := meta.(*AWSClient).ec2conn
 		req := &ec2.DescribeSpotFleetRequestsInput{
-			SpotFleetRequestIds: []*string{aws.String(d.Id())},
+			SpotFleetRequestIds: []*string{aws.String(id)},
 		}
 		resp, err := conn.DescribeSpotFleetRequests(req)
 

--- a/aws/resource_aws_spot_fleet_request_test.go
+++ b/aws/resource_aws_spot_fleet_request_test.go
@@ -34,7 +34,7 @@ func TestAccAWSSpotFleetRequest_associatePublicIpAddress(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_spot_fleet_request.foo", "launch_specification.#", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.2633484960.associate_public_ip_address", "true"),
+						"aws_spot_fleet_request.foo", "launch_specification.24370212.associate_public_ip_address", "true"),
 				),
 			},
 		},
@@ -127,9 +127,9 @@ func TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_spot_fleet_request.foo", "launch_specification.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.335709043.availability_zone", "us-west-2a"),
+						"aws_spot_fleet_request.foo", "launch_specification.1991689378.availability_zone", "us-west-2a"),
 					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.1671188867.availability_zone", "us-west-2b"),
+						"aws_spot_fleet_request.foo", "launch_specification.19404370.availability_zone", "us-west-2b"),
 				),
 			},
 		},
@@ -181,9 +181,9 @@ func TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_spot_fleet_request.foo", "launch_specification.#", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.335709043.instance_type", "m1.small"),
+						"aws_spot_fleet_request.foo", "launch_specification.1991689378.instance_type", "m1.small"),
 					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.335709043.availability_zone", "us-west-2a"),
+						"aws_spot_fleet_request.foo", "launch_specification.1991689378.availability_zone", "us-west-2a"),
 					resource.TestCheckResourceAttr(
 						"aws_spot_fleet_request.foo", "launch_specification.590403189.instance_type", "m3.large"),
 					resource.TestCheckResourceAttr(
@@ -237,7 +237,7 @@ func TestAccAWSSpotFleetRequest_overriddingSpotPrice(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_spot_fleet_request.foo", "spot_request_state", "active"),
 					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "spot_price", "0.005"),
+						"aws_spot_fleet_request.foo", "spot_price", "0.035"),
 					resource.TestCheckResourceAttr(
 						"aws_spot_fleet_request.foo", "launch_specification.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -245,9 +245,9 @@ func TestAccAWSSpotFleetRequest_overriddingSpotPrice(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_spot_fleet_request.foo", "launch_specification.4143232216.instance_type", "m3.large"),
 					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.335709043.spot_price", ""), //there will not be a value here since it's not overriding
+						"aws_spot_fleet_request.foo", "launch_specification.1991689378.spot_price", ""), //there will not be a value here since it's not overriding
 					resource.TestCheckResourceAttr(
-						"aws_spot_fleet_request.foo", "launch_specification.335709043.instance_type", "m1.small"),
+						"aws_spot_fleet_request.foo", "launch_specification.1991689378.instance_type", "m1.small"),
 				),
 			},
 		},
@@ -500,33 +500,10 @@ resource "aws_key_pair" "debugging" {
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
-resource "aws_iam_policy" "test-policy" {
-  name = "test-policy-%d"
-  path = "/"
-  description = "Spot Fleet Request ACCTest Policy"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Action": [
-       "ec2:DescribeImages",
-       "ec2:DescribeSubnets",
-       "ec2:RequestSpotInstances",
-       "ec2:TerminateInstances",
-       "ec2:DescribeInstanceStatus",
-       "iam:PassRole"
-        ],
-    "Resource": ["*"]
-  }]
-}
-EOF
-}
-
 resource "aws_iam_policy_attachment" "test-attach" {
     name = "test-attachment-%d"
     roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "${aws_iam_policy.test-policy.arn}"
+    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
 }
 
 resource "aws_iam_role" "test-role" {
@@ -553,17 +530,19 @@ EOF
 
 resource "aws_spot_fleet_request" "foo" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.005"
+    spot_price = "0.027"
     target_capacity = 2
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
     launch_specification {
         instance_type = "m1.small"
-        ami = "ami-d06a90b0"
+        ami = "ami-516b9131"
         key_name = "${aws_key_pair.debugging.key_name}"
         associate_public_ip_address = true
     }
-}`, rName, rInt, rInt, rName)
+	depends_on = ["aws_iam_policy_attachment.test-attach"]
+}`, rName, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestConfig(rName string, rInt int) string {
@@ -630,9 +609,10 @@ resource "aws_spot_fleet_request" "foo" {
     target_capacity = 2
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
     launch_specification {
         instance_type = "m1.small"
-        ami = "ami-d06a90b0"
+        ami = "ami-516b9131"
         key_name = "${aws_key_pair.debugging.key_name}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
@@ -704,9 +684,10 @@ resource "aws_spot_fleet_request" "foo" {
     target_capacity = 2
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
     launch_specification {
         instance_type = "m1.small"
-        ami = "ami-d06a90b0"
+        ami = "ami-516b9131"
         key_name = "${aws_key_pair.debugging.key_name}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
@@ -778,17 +759,18 @@ resource "aws_spot_fleet_request" "foo" {
     target_capacity = 2
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
     launch_specification {
         instance_type = "m1.small"
-        ami = "ami-d06a90b0"
+        ami = "ami-516b9131"
         key_name = "${aws_key_pair.debugging.key_name}"
-	availability_zone = "us-west-2a"
+        availability_zone = "us-west-2a"
     }
     launch_specification {
         instance_type = "m1.small"
-        ami = "ami-d06a90b0"
+        ami = "ami-516b9131"
         key_name = "${aws_key_pair.debugging.key_name}"
-	availability_zone = "us-west-2b"
+        availability_zone = "us-west-2b"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
@@ -871,21 +853,22 @@ resource "aws_subnet" "bar" {
 
 resource "aws_spot_fleet_request" "foo" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.005"
+    spot_price = "0.025"
     target_capacity = 4
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
     launch_specification {
         instance_type = "m3.large"
         ami = "ami-d0f506b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-	subnet_id = "${aws_subnet.foo.id}"
+        subnet_id = "${aws_subnet.foo.id}"
     }
     launch_specification {
         instance_type = "m3.large"
         ami = "ami-d0f506b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-	subnet_id = "${aws_subnet.bar.id}"
+        subnet_id = "${aws_subnet.bar.id}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
@@ -952,13 +935,14 @@ EOF
 
 resource "aws_spot_fleet_request" "foo" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.005"
+    spot_price = "0.025"
     target_capacity = 2
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
     launch_specification {
         instance_type = "m1.small"
-        ami = "ami-d06a90b0"
+        ami = "ami-516b9131"
         key_name = "${aws_key_pair.debugging.key_name}"
         availability_zone = "us-west-2a"
     }
@@ -1043,21 +1027,22 @@ resource "aws_subnet" "foo" {
 
 resource "aws_spot_fleet_request" "foo" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.005"
+    spot_price = "0.035"
     target_capacity = 4
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
+	wait_for_fulfillment = true
     launch_specification {
         instance_type = "m3.large"
         ami = "ami-d0f506b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-	subnet_id = "${aws_subnet.foo.id}"
+        subnet_id = "${aws_subnet.foo.id}"
     }
     launch_specification {
         instance_type = "r3.large"
         ami = "ami-d0f506b0"
         key_name = "${aws_key_pair.debugging.key_name}"
-	subnet_id = "${aws_subnet.foo.id}"
+        subnet_id = "${aws_subnet.foo.id}"
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
@@ -1124,13 +1109,14 @@ EOF
 
 resource "aws_spot_fleet_request" "foo" {
     iam_fleet_role = "${aws_iam_role.test-role.arn}"
-    spot_price = "0.005"
+    spot_price = "0.035"
     target_capacity = 2
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
     launch_specification {
         instance_type = "m1.small"
-        ami = "ami-d06a90b0"
+        ami = "ami-516b9131"
         key_name = "${aws_key_pair.debugging.key_name}"
         availability_zone = "us-west-2a"
     }
@@ -1211,6 +1197,7 @@ resource "aws_spot_fleet_request" "foo" {
     valid_until = "2019-11-04T20:44:20Z"
     allocation_strategy = "diversified"
     terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
     launch_specification {
         instance_type = "m1.small"
         ami = "ami-d06a90b0"
@@ -1298,6 +1285,7 @@ resource "aws_spot_fleet_request" "foo" {
     target_capacity = 10
     valid_until = "2019-11-04T20:44:20Z"
     terminate_instances_with_expiration = true
+    wait_for_fulfillment = true
     launch_specification {
         instance_type = "m3.large"
         ami = "ami-d06a90b0"

--- a/website/docs/r/spot_fleet_request.html.markdown
+++ b/website/docs/r/spot_fleet_request.html.markdown
@@ -95,6 +95,9 @@ across different markets and instance types.
     [reference documentation](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_SpotFleetLaunchSpecification.html). Any normal [`aws_instance`](instance.html) parameter that corresponds to those inputs may be used.
 
 * `spot_price` - (Required) The bid price per unit hour.
+* `wait_for_fulfillment` - (Optional; Default: false) If set, Terraform will
+  wait for the Spot Request to be fulfilled, and will throw an error if the
+  timeout of 10m is reached.
 * `target_capacity` - The number of units to request. You can choose to set the
   target capacity in terms of instances or a performance characteristic that is
 important to your application workload, such as vCPUs, memory, or I/O.
@@ -109,6 +112,12 @@ lowestPrice.
 * `valid_until` - The end date and time of the request, in UTC ISO8601 format
   (for example, YYYY-MM-DDTHH:MM:SSZ). At this point, no new Spot instance
 requests are placed or enabled to fulfill the request. Defaults to 24 hours.
+
+### Timeouts
+
+The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/docs/configuration/resources.html#timeouts) for certain actions:
+
+* `create` - (Defaults to 10 mins) Used when requesting the spot instance (only valid if `wait_for_fulfillment = true`)
 
 ## Attributes Reference
 


### PR DESCRIPTION
> emerged from terraform-providers/terraform-provider-aws#1203

*work-in-progress: There are still many tests to fix. Fixing them will take some time, since I am busy right now.*

This adds the `wait_for_fulfillment` argument to `aws_spot_fleet_request`. Also many of the acceptance test actually don't work, therefore I am fixing everything which doesn't require terraform-providers/terraform-provider-aws#1203 and which I am able to fix. The most code is copied from [`aws_spot_instance_request`](https://github.com/terraform-providers/terraform-provider-aws/blob/423e66d/aws/resource_aws_spot_instance_request.go).

**Progress so far:**

* [ ] `TestAccAWSSpotFleetRequest_associatePublicIpAddress`
* [ ] `TestAccAWSSpotFleetRequest_changePriceForcesNewRequest`
* [ ] `TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion`
* [ ] `TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList`
* [ ] `TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList`
* [ ] `TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz`
* [ ] `TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet`
* [ ] `TestAccAWSSpotFleetRequest_overriddingSpotPrice`
* [x] `TestAccAWSSpotFleetRequest_diversifiedAllocation` – Works out of the box.
* [x] `TestAccAWSSpotFleetRequest_withWeightedCapacity` – Works out of the box.
* [ ] `TestAccAWSSpotFleetRequest_withEBSDisk`
* [ ] `TestAccAWSSpotFleetRequest_placementTenancy` – This is hard to fix, since I get this error message regardless of which instance type I chose: `Instance type m4.large is not supported for the tenancy value (dedicated)`
* [ ] `TestAccAWSSpotFleetRequest_CannotUseEmptyKeyName`

**Other notes:**

* The AMI for `m1.small` instances don't work, since they don't support HVM images: `
Repeated errors have occured processing the launch specification "m1.small, ami-d06a90b0, Linux/UNIX, us-west-2a". It will not be retried for at least 13 minutes. Error message: com.amazonaws.services.ec2.model.AmazonEC2Exception: Non-Windows instances with a virtualization type of 'hvm' are currently not supported for this instance type. (Service: AmazonEC2; Status Code: 400; Error Code: InvalidParameterCombination)`